### PR TITLE
[Chore] Update the git clone command tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We have three methods to launch `onnx-modifier` now.
 Clone the repo and install the required Python packages by
 
 ```bash
-git clone git@github.com:ZhangGe6/onnx-modifier.git
+git clone https://github.com/ZhangGe6/onnx-modifier.git
 cd onnx-modifier
 
 pip install -r requirements.txt


### PR DESCRIPTION
# Motivation
- We should use Web URL to clone this repo instead of the ssh way.

![image](https://github.com/ZhangGe6/onnx-modifier/assets/32220263/e0388efb-0213-43d5-95cd-0e693d3a3bff)
